### PR TITLE
add install_scripts_to_libexec function

### DIFF
--- a/ament_python/script_dir.py
+++ b/ament_python/script_dir.py
@@ -1,0 +1,37 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Override the setup.py command line argument --script_dir."""
+
+import os
+import sys
+
+
+def install_scripts_to_libexec(package_name):
+    """Override sys.argv to install scripts into lib/<pkgname>."""
+    command_args = {'develop': '--script-dir', 'install': '--install-scripts'}
+    libexec_path = os.path.join('$base', 'lib', package_name)
+    for command, arg in command_args.items():
+        if arg in sys.argv:
+            # update existing argument
+            arg_index = sys.argv.index(arg)
+            sys.argv[arg_index + 1] = libexec_path
+        else:
+            # insert additional arguments after the command
+            try:
+                command_index = sys.argv.index(command)
+            except ValueError:
+                continue
+            sys.argv[command_index + 1:command_index + 1] = \
+                [arg, libexec_path]

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_python</name>
+  <version>0.0.0</version>
+  <description>Python API for ament Python packages.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+from setuptools import find_packages
+from setuptools import setup
+
+setup(
+    name='ament_python',
+    version='0.0.0',
+    packages=find_packages(exclude=['test']),
+    install_requires=['setuptools'],
+    author='Dirk Thomas',
+    author_email='dthomas@osrfoundation.org',
+    maintainer='Dirk Thomas',
+    maintainer_email='dthomas@osrfoundation.org',
+    url='https://github.com/ament/ament_python',
+    download_url='https://github.com/ament/ament_python/releases',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description='Python API for ament Python packages.',
+    long_description='Python API for ament Python packages.',
+    license='Apache License, Version 2.0',
+    test_suite='test',
+)

--- a/test/test_copyright.py
+++ b/test/test_copyright.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+
+
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main
+
+
+def test_flake8():
+    rc = main(argv=[])
+    assert rc == 0, 'Found errors'

--- a/test/test_pep257.py
+++ b/test/test_pep257.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+
+
+def test_pep257():
+    rc = main(argv=[])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
The function `install_scripts_to_libexec()` is supposed to be called in Python packages in their `setup.py` file before calling `setup(...)`. It will install all scripts into the `lib/<pkgname>` folder rather than `bin`.

This will allow us to update existing Python package to separate scripts by their package name and use `ros2 run`.

Connect to ros2/ros2#364.

Ready for review.